### PR TITLE
chore: enable clippy pedantic+nursery+cargo and fix all warnings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,15 +31,39 @@ indicatif = "0.17"
 burn = { version = "0.20", default-features = false, features = ["std", "ndarray", "autodiff", "train"] }
 rust-mcp-sdk = { version = "0.9", features = ["server"] }
 async-trait = "0.1"
+unicode-normalization = "0.1"
+
 [target.'cfg(unix)'.dependencies]
 nix = { version = "0.29", features = ["signal", "process"] }
-unicode-normalization = "0.1"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 burn = { version = "0.20", default-features = false, features = ["std", "ndarray", "autodiff", "train", "accelerate"] }
 
 [dev-dependencies]
 tempfile = "3"
+
+[lints.clippy]
+pedantic = { level = "warn", priority = -1 }
+nursery = { level = "warn", priority = -1 }
+cargo = { level = "warn", priority = -1 }
+# Restriction lints for CLI application safety
+unwrap_used = "warn"
+expect_used = "warn"
+panic_in_result_fn = "warn"
+unwrap_in_result = "warn"
+todo = "warn"
+unimplemented = "warn"
+dbg_macro = "warn"
+missing_assert_message = "warn"
+# Intentional opt-outs from pedantic/nursery
+module_name_repetitions = "allow"
+missing_errors_doc = "allow"
+missing_panics_doc = "allow"
+# Numeric casts are pervasive and intentional in ML/embedding code
+cast_precision_loss = "allow"
+cast_possible_truncation = "allow"
+cast_sign_loss = "allow"
+cast_possible_wrap = "allow"
 
 [profile.release]
 opt-level = 3

--- a/_typos.toml
+++ b/_typos.toml
@@ -3,3 +3,4 @@ NdArray = "NdArray"
 
 [default.extend-words]
 Nd = "Nd"
+multicat = "multicat"

--- a/src/benchmark.rs
+++ b/src/benchmark.rs
@@ -74,12 +74,12 @@ pub fn percentile(sorted: &[Duration], pct: f64) -> Duration {
     sorted[idx]
 }
 
-/// Compute coefficient of variation (std_dev / mean) for durations.
+/// Compute coefficient of variation (std-dev / mean) for durations.
 pub fn coefficient_of_variation(durations: &[Duration]) -> f64 {
     if durations.is_empty() {
         return 0.0;
     }
-    let mean = durations.iter().map(|d| d.as_secs_f64()).sum::<f64>() / durations.len() as f64;
+    let mean = durations.iter().map(Duration::as_secs_f64).sum::<f64>() / durations.len() as f64;
     if mean == 0.0 {
         return 0.0;
     }
@@ -97,9 +97,9 @@ pub fn coefficient_of_variation(durations: &[Duration]) -> f64 {
 /// Scoring strategy for the benchmark.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ScoringStrategy {
-    /// Original: pos_score >= threshold && pos_score > neg_score
+    /// Original: `pos_score >= threshold && pos_score > neg_score`
     Threshold,
-    /// Margin-based: (pos_score - neg_score) > margin
+    /// Margin-based: `(pos_score - neg_score) > margin`
     Margin(u32), // margin × 1000 (stored as int to derive Eq)
     /// Adaptive: threshold calibrated from negative score distribution
     Adaptive,
@@ -110,10 +110,10 @@ impl ScoringStrategy {
         Self::Margin((m * 1000.0) as u32)
     }
 
-    pub fn name(&self) -> String {
+    pub fn name(self) -> String {
         match self {
             Self::Threshold => "threshold".to_string(),
-            Self::Margin(m) => format!("margin-{:.2}", *m as f32 / 1000.0),
+            Self::Margin(m) => format!("margin-{:.2}", m as f32 / 1000.0),
             Self::Adaptive => "adaptive".to_string(),
         }
     }
@@ -281,7 +281,7 @@ pub fn compare_strategies(
             .iter()
             .filter(|(prompt, _)| {
                 let emb = engine.embed_one(&prompt.text).ok();
-                if let Some(emb) = emb {
+                emb.is_some_and(|emb| {
                     let mlp_result =
                         classifier::classify_with_mlp(&emb, &prompt.text, &trained_model);
                     match prompt.polarity {
@@ -290,9 +290,7 @@ pub fn compare_strategies(
                         }
                         Polarity::Negative => !mlp_result.is_match,
                     }
-                } else {
-                    false
-                }
+                })
             })
             .count();
 
@@ -488,12 +486,12 @@ pub fn run_benchmark(
 ) -> Result<BenchmarkRun> {
     let total_steps = models.len() * datasets.len();
     let pb = ProgressBar::new(total_steps as u64);
-    pb.set_style(
-        ProgressStyle::default_bar()
-            .template("{spinner:.green} [{bar:40}] {pos}/{len} {msg}")
-            .unwrap()
-            .progress_chars("=> "),
-    );
+    #[allow(clippy::literal_string_with_formatting_args)]
+    let style = ProgressStyle::default_bar()
+        .template("{spinner:.green} [{bar:40}] {pos}/{len} {msg}")
+        .context("invalid progress bar template")?
+        .progress_chars("=> ");
+    pb.set_style(style);
 
     let mut results = Vec::new();
 
@@ -608,11 +606,12 @@ pub fn print_table(run: &BenchmarkRun) {
 
         for model_result in &run.results {
             if let Some(ds) = model_result.datasets.iter().find(|d| d.dataset == *ds_name) {
-                let edge_acc = (ds.accuracy_by_tier.edge_pos + ds.accuracy_by_tier.edge_neg) / 2.0;
+                let edge_acc =
+                    f64::midpoint(ds.accuracy_by_tier.edge_pos, ds.accuracy_by_tier.edge_neg);
 
                 if ds.accuracy > best_accuracy {
                     best_accuracy = ds.accuracy;
-                    best_model = model_result.model.clone();
+                    best_model.clone_from(&model_result.model);
                 }
 
                 let cv_display = if ds.latency_cv > 0.3 {

--- a/src/classifier.rs
+++ b/src/classifier.rs
@@ -53,14 +53,16 @@ pub enum ClassifyResult {
 
 #[allow(dead_code)]
 impl ClassifyResult {
-    pub fn is_match(&self) -> bool {
+    #[must_use]
+    pub const fn is_match(&self) -> bool {
         match self {
             Self::Binary(r) => r.is_match,
             Self::MultiCategory(r) => r.is_match,
         }
     }
 
-    pub fn confidence(&self) -> f32 {
+    #[must_use]
+    pub const fn confidence(&self) -> f32 {
         match self {
             Self::Binary(r) => r.confidence,
             Self::MultiCategory(r) => r.confidence,
@@ -139,11 +141,14 @@ fn classify_with_text(
                     .unwrap_or(std::cmp::Ordering::Equal)
             });
 
-            let best = all_scores.first().cloned().unwrap_or(CategoryScore {
-                category: String::new(),
-                score: 0.0,
-                top_phrase: String::new(),
-            });
+            let best = all_scores
+                .first()
+                .cloned()
+                .unwrap_or_else(|| CategoryScore {
+                    category: String::new(),
+                    score: 0.0,
+                    top_phrase: String::new(),
+                });
 
             ClassifyResult::MultiCategory(MultiCategoryResult {
                 is_match: best.score >= threshold,
@@ -259,7 +264,7 @@ pub fn classify_with_multi_mlp(
 
     let logits = trained_model.classifier.forward(input);
     let probs = burn::tensor::activation::softmax(logits, 1);
-    let probs_data: Vec<f32> = probs.into_data().to_vec().unwrap();
+    let probs_data: Vec<f32> = probs.into_data().to_vec().unwrap_or_default();
 
     // Build per-category scores with top phrase from cosine similarity.
     let mut all_scores: Vec<CategoryScore> = trained_model
@@ -271,11 +276,13 @@ pub fn classify_with_multi_mlp(
                 .category_phrases
                 .iter()
                 .find(|(n, _)| n == name)
-                .map(|(_, phrases)| {
-                    let embeddings = &trained_model.category_embeddings[i].1;
-                    best_match(text_embedding, embeddings, phrases)
-                })
-                .unwrap_or((0.0, String::new()));
+                .map_or_else(
+                    || (0.0, String::new()),
+                    |(_, phrases)| {
+                        let embeddings = &trained_model.category_embeddings[i].1;
+                        best_match(text_embedding, embeddings, phrases)
+                    },
+                );
 
             CategoryScore {
                 category: name.clone(),
@@ -293,11 +300,14 @@ pub fn classify_with_multi_mlp(
             .unwrap_or(std::cmp::Ordering::Equal)
     });
 
-    let best = all_scores.first().cloned().unwrap_or(CategoryScore {
-        category: String::new(),
-        score: 0.0,
-        top_phrase: String::new(),
-    });
+    let best = all_scores
+        .first()
+        .cloned()
+        .unwrap_or_else(|| CategoryScore {
+            category: String::new(),
+            score: 0.0,
+            top_phrase: String::new(),
+        });
 
     MultiCategoryResult {
         is_match: best.score >= threshold,
@@ -317,7 +327,7 @@ fn best_match(query: &Embedding, embeddings: &[Embedding], phrases: &[String]) -
         let score = cosine_similarity(query, emb);
         if score > best_score {
             best_score = score;
-            best_phrase = phrase.clone();
+            phrase.clone_into(&mut best_phrase);
         }
     }
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -16,9 +16,8 @@ pub fn try_daemon_request(config: &AppConfig, request: &DaemonRequest) -> Option
     let socket_path = config.socket_path();
 
     // Try to connect
-    let stream = match UnixStream::connect(&socket_path) {
-        Ok(s) => s,
-        Err(_) => return None,
+    let Ok(stream) = UnixStream::connect(&socket_path) else {
+        return None;
     };
 
     // Set timeouts to avoid hanging
@@ -44,14 +43,12 @@ fn send_request(mut stream: UnixStream, request: &DaemonRequest) -> Result<Daemo
 
 /// Check if the daemon process is alive by reading the PID file and signaling.
 pub fn is_daemon_alive(pid_path: &Path) -> bool {
-    let content = match std::fs::read_to_string(pid_path) {
-        Ok(c) => c,
-        Err(_) => return false,
+    let Ok(content) = std::fs::read_to_string(pid_path) else {
+        return false;
     };
 
-    let pid: i32 = match content.trim().parse() {
-        Ok(p) => p,
-        Err(_) => return false,
+    let Ok(pid) = content.trim().parse::<i32>() else {
+        return false;
     };
 
     // kill(pid, None) = signal 0 = check if process exists
@@ -66,6 +63,8 @@ fn cleanup_stale_files(config: &AppConfig) {
 
 /// Spawn the daemon as a detached background process.
 fn spawn_daemon(config: &AppConfig) -> Result<()> {
+    use std::os::unix::io::AsRawFd;
+
     let exe = std::env::current_exe().context("cannot determine current executable path")?;
 
     // Ensure cache dir exists for the lock file
@@ -75,7 +74,6 @@ fn spawn_daemon(config: &AppConfig) -> Result<()> {
     let lock_path = config.lock_path();
     let lock_file = std::fs::File::create(&lock_path).context("creating daemon lock file")?;
 
-    use std::os::unix::io::AsRawFd;
     let fd = lock_file.as_raw_fd();
     let got_lock = unsafe { nix::libc::flock(fd, nix::libc::LOCK_EX | nix::libc::LOCK_NB) == 0 };
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -73,6 +73,7 @@ impl AppConfig {
     const DEFAULT_IDLE_TIMEOUT: u64 = 300; // 5 minutes
 
     /// Load config with 3-layer precedence: CLI > env > TOML file > defaults.
+    #[allow(clippy::unnecessary_wraps)]
     pub fn load(overrides: CliOverrides) -> Result<Self> {
         let config_dir = Self::config_dir();
         let file_config = Self::load_file(&config_dir);
@@ -150,26 +151,30 @@ impl AppConfig {
     }
 
     fn config_dir() -> PathBuf {
-        directories::ProjectDirs::from("", "", "computer-says-no")
-            .map(|d| d.config_dir().to_owned())
-            .unwrap_or_else(|| PathBuf::from(".config/computer-says-no"))
+        directories::ProjectDirs::from("", "", "computer-says-no").map_or_else(
+            || PathBuf::from(".config/computer-says-no"),
+            |d| d.config_dir().to_owned(),
+        )
     }
 
     fn default_cache_dir() -> PathBuf {
-        directories::ProjectDirs::from("", "", "computer-says-no")
-            .map(|d| d.cache_dir().to_owned())
-            .unwrap_or_else(|| PathBuf::from(".cache/computer-says-no"))
+        directories::ProjectDirs::from("", "", "computer-says-no").map_or_else(
+            || PathBuf::from(".cache/computer-says-no"),
+            |d| d.cache_dir().to_owned(),
+        )
     }
 
     fn load_file(config_dir: &Path) -> FileConfig {
         let path = config_dir.join("config.toml");
-        match std::fs::read_to_string(&path) {
-            Ok(content) => toml::from_str(&content).unwrap_or_else(|e| {
-                tracing::warn!(path = %path.display(), error = %e, "invalid config file, using defaults");
-                FileConfig::default()
-            }),
-            Err(_) => FileConfig::default(),
-        }
+        std::fs::read_to_string(&path).map_or_else(
+            |_| FileConfig::default(),
+            |content| {
+                toml::from_str(&content).unwrap_or_else(|e| {
+                    tracing::warn!(path = %path.display(), error = %e, "invalid config file, using defaults");
+                    FileConfig::default()
+                })
+            },
+        )
     }
 
     /// Resolve the sets directory, checking for bundled fallback.

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -32,7 +32,7 @@ pub struct DaemonResponse {
 }
 
 impl DaemonResponse {
-    pub fn success(result: serde_json::Value) -> Self {
+    pub const fn success(result: serde_json::Value) -> Self {
         Self {
             ok: true,
             result: Some(result),
@@ -68,7 +68,7 @@ impl IdleTracker {
     fn now() -> u64 {
         SystemTime::now()
             .duration_since(UNIX_EPOCH)
-            .unwrap()
+            .unwrap_or_default()
             .as_secs()
     }
 
@@ -92,7 +92,7 @@ struct DaemonHandler {
 }
 
 impl DaemonHandler {
-    fn new(
+    const fn new(
         engine: EmbeddingEngine,
         reference_sets: Vec<ReferenceSet>,
         trained_models: Vec<TrainedModel>,
@@ -108,64 +108,56 @@ impl DaemonHandler {
         }
     }
 
-    fn dispatch(&self, req: DaemonRequest) -> DaemonResponse {
+    fn dispatch(&self, req: &DaemonRequest) -> DaemonResponse {
         match req.command.as_str() {
-            "classify" => self.handle_classify(req.args),
-            "embed" => self.handle_embed(req.args),
-            "similarity" => self.handle_similarity(req.args),
+            "classify" => self.handle_classify(&req.args),
+            "embed" => self.handle_embed(&req.args),
+            "similarity" => self.handle_similarity(&req.args),
             other => DaemonResponse::error(format!("unknown command: {other}")),
         }
     }
 
-    fn handle_classify(&self, args: serde_json::Value) -> DaemonResponse {
-        let text = match args.get("text").and_then(|v| v.as_str()) {
-            Some(t) => t,
-            None => return DaemonResponse::error("missing 'text' field"),
+    fn handle_classify(&self, args: &serde_json::Value) -> DaemonResponse {
+        let Some(text) = args.get("text").and_then(|v| v.as_str()) else {
+            return DaemonResponse::error("missing 'text' field");
         };
-        let set_name = match args.get("set").and_then(|v| v.as_str()) {
-            Some(s) => s,
-            None => return DaemonResponse::error("missing 'set' field"),
+        let Some(set_name) = args.get("set").and_then(|v| v.as_str()) else {
+            return DaemonResponse::error("missing 'set' field");
         };
 
-        let set = match self
+        let Some(set) = self
             .reference_sets
             .iter()
             .find(|s| s.metadata.name == set_name)
-        {
-            Some(s) => s,
-            None => {
-                let available: Vec<_> = self
-                    .reference_sets
-                    .iter()
-                    .map(|s| s.metadata.name.as_str())
-                    .collect();
-                return DaemonResponse::error(format!(
-                    "reference set '{}' not found. Available: {}",
-                    set_name,
-                    available.join(", ")
-                ));
-            }
+        else {
+            let available: Vec<_> = self
+                .reference_sets
+                .iter()
+                .map(|s| s.metadata.name.as_str())
+                .collect();
+            return DaemonResponse::error(format!(
+                "reference set '{}' not found. Available: {}",
+                set_name,
+                available.join(", ")
+            ));
         };
 
-        let trained_models = match self.trained_models.lock() {
-            Ok(m) => m,
-            Err(_) => return DaemonResponse::error("models lock poisoned"),
+        let Ok(trained_models) = self.trained_models.lock() else {
+            return DaemonResponse::error("models lock poisoned");
         };
         let trained_model = trained_models
             .iter()
             .find(|m| m.reference_set_name == set_name);
 
-        let trained_multi_models = match self.trained_multi_models.lock() {
-            Ok(m) => m,
-            Err(_) => return DaemonResponse::error("multi models lock poisoned"),
+        let Ok(trained_multi_models) = self.trained_multi_models.lock() else {
+            return DaemonResponse::error("multi models lock poisoned");
         };
         let trained_multi_model = trained_multi_models
             .iter()
             .find(|m| m.reference_set_name == set_name);
 
-        let mut engine = match self.engine.lock() {
-            Ok(e) => e,
-            Err(_) => return DaemonResponse::error("engine lock poisoned"),
+        let Ok(mut engine) = self.engine.lock() else {
+            return DaemonResponse::error("engine lock poisoned");
         };
 
         match classifier::classify_text(&mut engine, text, set, trained_model, trained_multi_model)
@@ -178,15 +170,13 @@ impl DaemonHandler {
         }
     }
 
-    fn handle_embed(&self, args: serde_json::Value) -> DaemonResponse {
-        let text = match args.get("text").and_then(|v| v.as_str()) {
-            Some(t) => t,
-            None => return DaemonResponse::error("missing 'text' field"),
+    fn handle_embed(&self, args: &serde_json::Value) -> DaemonResponse {
+        let Some(text) = args.get("text").and_then(|v| v.as_str()) else {
+            return DaemonResponse::error("missing 'text' field");
         };
 
-        let mut engine = match self.engine.lock() {
-            Ok(e) => e,
-            Err(_) => return DaemonResponse::error("engine lock poisoned"),
+        let Ok(mut engine) = self.engine.lock() else {
+            return DaemonResponse::error("engine lock poisoned");
         };
 
         match engine.embed_one(text) {
@@ -202,19 +192,16 @@ impl DaemonHandler {
         }
     }
 
-    fn handle_similarity(&self, args: serde_json::Value) -> DaemonResponse {
-        let a = match args.get("a").and_then(|v| v.as_str()) {
-            Some(t) => t,
-            None => return DaemonResponse::error("missing 'a' field"),
+    fn handle_similarity(&self, args: &serde_json::Value) -> DaemonResponse {
+        let Some(a) = args.get("a").and_then(|v| v.as_str()) else {
+            return DaemonResponse::error("missing 'a' field");
         };
-        let b = match args.get("b").and_then(|v| v.as_str()) {
-            Some(t) => t,
-            None => return DaemonResponse::error("missing 'b' field"),
+        let Some(b) = args.get("b").and_then(|v| v.as_str()) else {
+            return DaemonResponse::error("missing 'b' field");
         };
 
-        let mut engine = match self.engine.lock() {
-            Ok(e) => e,
-            Err(_) => return DaemonResponse::error("engine lock poisoned"),
+        let Ok(mut engine) = self.engine.lock() else {
+            return DaemonResponse::error("engine lock poisoned");
         };
 
         match engine.embed(&[a, b]) {
@@ -236,6 +223,7 @@ unsafe impl Sync for DaemonHandler {}
 
 // --- Main daemon entry point ---
 
+#[allow(clippy::too_many_lines)]
 pub fn run_daemon(config: &AppConfig) -> Result<()> {
     use crate::mlp;
     use crate::reference_set::load_all_reference_sets;
@@ -344,7 +332,7 @@ pub fn run_daemon(config: &AppConfig) -> Result<()> {
                                 let mut lines = BufReader::new(reader).lines();
                                 if let Ok(Some(line)) = lines.next_line().await {
                                     let response = match serde_json::from_str::<DaemonRequest>(&line) {
-                                        Ok(req) => handler.dispatch(req),
+                                        Ok(req) => handler.dispatch(&req),
                                         Err(e) => DaemonResponse::error(format!("invalid request: {e}")),
                                     };
                                     if let Ok(json) = serde_json::to_string(&response) {

--- a/src/embedding_cache.rs
+++ b/src/embedding_cache.rs
@@ -6,8 +6,9 @@ use anyhow::{Context, Result};
 use crate::model::Embedding;
 
 /// Header for the binary cache file format.
-/// Format: magic(4) + version(1) + dimensions(4 LE) + num_groups(4 LE)
-/// Per group: name_len(4 LE) + name(utf8) + num_embeddings(4 LE) + embedding_data(f32 LE)
+///
+/// Format: `magic(4) + version(1) + dimensions(4 LE) + num_groups(4 LE)`
+/// Per group: `name_len(4 LE) + name(utf8) + num_embeddings(4 LE) + embedding_data(f32 LE)`
 const CACHE_MAGIC: &[u8; 4] = b"CSN\x00";
 const CACHE_VERSION: u8 = 1;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -178,6 +178,7 @@ enum BenchmarkAction {
     },
 }
 
+#[allow(clippy::too_many_lines)]
 fn main() -> Result<()> {
     let cli = Cli::parse();
 
@@ -216,7 +217,10 @@ fn main() -> Result<()> {
             cmd_similarity(&config, &a, &b)
         }
 
-        Command::Models => cmd_models(),
+        Command::Models => {
+            cmd_models();
+            Ok(())
+        }
 
         Command::Mcp => {
             let config = AppConfig::load(CliOverrides::default())?;
@@ -255,12 +259,12 @@ fn main() -> Result<()> {
                 cmd_benchmark_run(
                     &config,
                     model_filter,
-                    dataset,
+                    dataset.as_ref(),
                     iterations,
                     warmup,
                     json,
-                    output,
-                    compare,
+                    output.as_ref(),
+                    compare.as_ref(),
                 )
             }
             BenchmarkAction::CompareStrategies {
@@ -439,7 +443,7 @@ fn cmd_similarity(config: &AppConfig, a: &str, b: &str) -> Result<()> {
                     .result
                     .as_ref()
                     .and_then(|r| r.get("similarity"))
-                    .and_then(|v| v.as_f64())
+                    .and_then(serde_json::Value::as_f64)
                 {
                     println!("{sim:.4}");
                     return Ok(());
@@ -590,13 +594,12 @@ fn cmd_mcp(config: &AppConfig) -> Result<()> {
 
 // --- Local commands ---
 
-fn cmd_models() -> Result<()> {
+fn cmd_models() {
     println!("{:<30} {:>6}", "MODEL", "DIM");
     println!("{}", "-".repeat(38));
     for m in ModelChoice::all() {
         println!("{:<30} {:>6}", m.as_str(), m.dimensions());
     }
-    Ok(())
 }
 
 fn cmd_sets_list(config: &AppConfig) -> Result<()> {
@@ -652,12 +655,12 @@ fn cmd_sets_list(config: &AppConfig) -> Result<()> {
 fn cmd_benchmark_run(
     config: &AppConfig,
     model_filter: Option<ModelChoice>,
-    dataset_filter: Option<String>,
+    dataset_filter: Option<&String>,
     iterations: usize,
     warmup: usize,
     json: bool,
-    output: Option<PathBuf>,
-    compare: Option<PathBuf>,
+    output: Option<&PathBuf>,
+    compare: Option<&PathBuf>,
 ) -> Result<()> {
     let datasets_dir = &config.datasets_dir;
     let mut datasets = dataset::load_all_datasets(datasets_dir)?;
@@ -670,7 +673,7 @@ fn cmd_benchmark_run(
     }
 
     // Apply dataset filter
-    if let Some(ref filter) = dataset_filter {
+    if let Some(filter) = dataset_filter {
         datasets.retain(|d| d.name == *filter);
         if datasets.is_empty() {
             let available: Vec<_> = dataset::load_all_datasets(datasets_dir)?
@@ -686,11 +689,8 @@ fn cmd_benchmark_run(
     }
 
     // Determine models to test
-    let models: Vec<ModelChoice> = if let Some(m) = model_filter {
-        vec![m]
-    } else {
-        ModelChoice::all().to_vec()
-    };
+    let models: Vec<ModelChoice> =
+        model_filter.map_or_else(|| ModelChoice::all().to_vec(), |m| vec![m]);
 
     let sets_dir = config.resolve_sets_dir();
     let run = benchmark::run_benchmark(
@@ -700,7 +700,7 @@ fn cmd_benchmark_run(
         &config.cache_dir,
         warmup,
         iterations,
-        output.as_deref(),
+        output.map(PathBuf::as_path),
     )?;
 
     // Output results
@@ -712,7 +712,7 @@ fn cmd_benchmark_run(
     }
 
     // Save to file if requested
-    if let Some(ref path) = output {
+    if let Some(path) = output {
         let json_str = serde_json::to_string_pretty(&run)?;
         std::fs::write(path, json_str)
             .with_context(|| format!("writing results to {}", path.display()))?;
@@ -720,7 +720,7 @@ fn cmd_benchmark_run(
     }
 
     // Compare against previous run
-    if let Some(ref path) = compare {
+    if let Some(path) = compare {
         let prev_json = std::fs::read_to_string(path)
             .with_context(|| format!("reading previous results from {}", path.display()))?;
         let prev_run: benchmark::BenchmarkRun = serde_json::from_str(&prev_json)
@@ -824,10 +824,10 @@ fn cmd_generate_datasets(config: &AppConfig, output_dir: Option<PathBuf>) -> Res
 
 fn print_classify_result(result: &classifier::ClassifyResult, json: bool) {
     if json {
-        println!(
-            "{}",
-            serde_json::to_string_pretty(result).expect("serialization failed")
-        );
+        #[allow(clippy::expect_used)]
+        let output = serde_json::to_string_pretty(result)
+            .expect("ClassifyResult serialization is infallible");
+        println!("{output}");
     } else {
         match result {
             classifier::ClassifyResult::Binary(r) => {

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -17,9 +17,9 @@ use crate::reference_set::{ReferenceSet, ReferenceSetKind};
 
 /// Shared state for the MCP server handler.
 ///
-/// Uses Mutex for engine (not Sync due to fastembed internals) and trained_models
-/// (not Sync due to Burn NdArray). The Mutex makes McpHandler Send+Sync as
-/// required by the async ServerHandler trait.
+/// Uses Mutex for engine (not Sync due to fastembed internals) and `trained_models`
+/// (not Sync due to Burn `NdArray`). The Mutex makes `McpHandler` Send+Sync as
+/// required by the async `ServerHandler` trait.
 pub struct McpHandler {
     engine: Mutex<EmbeddingEngine>,
     reference_sets: Vec<ReferenceSet>,
@@ -33,7 +33,7 @@ pub struct McpHandler {
 unsafe impl Sync for McpHandler {}
 
 impl McpHandler {
-    pub fn new(
+    pub const fn new(
         engine: EmbeddingEngine,
         reference_sets: Vec<ReferenceSet>,
         trained_models: Vec<TrainedModel>,
@@ -101,7 +101,8 @@ tool_box!(
 // --- Tool implementations ---
 
 impl McpHandler {
-    fn handle_classify(&self, tool: ClassifyTool) -> Result<CallToolResult, CallToolError> {
+    #[allow(clippy::significant_drop_tightening)]
+    fn handle_classify(&self, tool: &ClassifyTool) -> Result<CallToolResult, CallToolError> {
         let set = self
             .reference_sets
             .iter()
@@ -187,13 +188,11 @@ impl McpHandler {
         Ok(CallToolResult::text_content(vec![TextContent::from(json)]))
     }
 
-    fn handle_embed(&self, tool: EmbedTool) -> Result<CallToolResult, CallToolError> {
-        let mut engine = self
+    fn handle_embed(&self, tool: &EmbedTool) -> Result<CallToolResult, CallToolError> {
+        let embedding = self
             .engine
             .lock()
-            .map_err(|_| CallToolError::from_message("engine lock poisoned".to_string()))?;
-
-        let embedding = engine
+            .map_err(|_| CallToolError::from_message("engine lock poisoned".to_string()))?
             .embed_one(&tool.text)
             .map_err(|e| CallToolError::from_message(e.to_string()))?;
 
@@ -208,13 +207,11 @@ impl McpHandler {
         Ok(CallToolResult::text_content(vec![TextContent::from(json)]))
     }
 
-    fn handle_similarity(&self, tool: SimilarityTool) -> Result<CallToolResult, CallToolError> {
-        let mut engine = self
+    fn handle_similarity(&self, tool: &SimilarityTool) -> Result<CallToolResult, CallToolError> {
+        let embeddings = self
             .engine
             .lock()
-            .map_err(|_| CallToolError::from_message("engine lock poisoned".to_string()))?;
-
-        let embeddings = engine
+            .map_err(|_| CallToolError::from_message("engine lock poisoned".to_string()))?
             .embed(&[&tool.a, &tool.b])
             .map_err(|e| CallToolError::from_message(e.to_string()))?;
 
@@ -255,7 +252,7 @@ impl ServerHandler for McpHandler {
         let tool: CsnTools =
             CsnTools::try_from(params).map_err(|e| CallToolError::from_message(e.to_string()))?;
 
-        match tool {
+        match &tool {
             CsnTools::ClassifyTool(t) => self.handle_classify(t),
             CsnTools::ListSetsTool(_) => self.handle_list_sets(),
             CsnTools::EmbedTool(t) => self.handle_embed(t),

--- a/src/mlp.rs
+++ b/src/mlp.rs
@@ -49,13 +49,13 @@ pub struct TrainedModel {
     /// blake3 hash of the reference set phrases (cache key for weight files).
     #[allow(dead_code)]
     pub content_hash: String,
-    /// The trained MLP classifier using the NdArray inference backend.
+    /// The trained MLP classifier using the `NdArray` inference backend.
     pub classifier: MlpClassifier<NdArray<f32>>,
     /// Cached positive phrase embeddings for cosine feature computation.
     pub pos_embeddings: Vec<Embedding>,
     /// Cached negative phrase embeddings for cosine feature computation.
     pub neg_embeddings: Vec<Embedding>,
-    /// Positive phrase strings for top_phrase reporting during classification.
+    /// Positive phrase strings for `top_phrase` reporting during classification.
     pub pos_phrases: Vec<String>,
 }
 
@@ -169,7 +169,7 @@ fn hash_ngram(ngram: &str) -> usize {
 
 /// Train an MLP binary classifier from positive and negative phrase embeddings.
 ///
-/// Builds training data by computing cosine features (max_pos, max_neg, margin)
+/// Builds training data by computing cosine features (`max_pos`, `max_neg`, margin)
 /// for each sample and concatenating with the raw embedding to form 387-dim input
 /// vectors. Uses `Autodiff<NdArray<f32>>` for training with Adam optimizer, BCE
 /// loss, and early stopping.
@@ -199,9 +199,8 @@ pub fn train_mlp(
 
     let embed_dim = pos_embeddings
         .first()
-        .or(neg_embeddings.first())
-        .map(|e| e.len())
-        .unwrap_or(384);
+        .or_else(|| neg_embeddings.first())
+        .map_or(384, Vec::len);
     let feature_dim = embed_dim + 3 + CHAR_NGRAM_DIM; // embedding + cosine + char n-grams
 
     // Configure MLP with actual feature dimension (varies by embedding model).
@@ -310,9 +309,9 @@ pub fn train_mlp(
 /// separators (positives first, then negatives), and returns the blake3 hex digest.
 pub fn content_hash(positive_phrases: &[String], negative_phrases: &[String]) -> String {
     let mut positives: Vec<&str> = positive_phrases.iter().map(String::as_str).collect();
-    positives.sort();
+    positives.sort_unstable();
     let mut negatives: Vec<&str> = negative_phrases.iter().map(String::as_str).collect();
-    negatives.sort();
+    negatives.sort_unstable();
 
     let combined: String = std::iter::once("v2-char256")
         .chain(positives)
@@ -417,9 +416,8 @@ pub fn train_models_at_startup(
         let embed_dim = bin
             .positive
             .first()
-            .or(bin.negative.first())
-            .map(|e| e.len())
-            .unwrap_or(384);
+            .or_else(|| bin.negative.first())
+            .map_or(384, Vec::len);
         let feature_dim = embed_dim + 3 + CHAR_NGRAM_DIM;
         let config = MlpConfig::new().with_input_dim(feature_dim);
 
@@ -601,7 +599,7 @@ pub struct TrainedMultiCatModel {
 /// For each category (in the order given), computes:
 /// - `max_sim`: maximum cosine similarity to any phrase in the category
 /// - `mean_sim`: mean cosine similarity across all phrases in the category
-/// - `margin`: max_sim minus the best max_sim of any *other* category
+/// - `margin`: `max_sim` minus the best `max_sim` of any *other* category
 ///
 /// Returns a vector of length `N * 3` where N is the number of categories.
 pub fn compute_multi_cosine_features(
@@ -706,10 +704,8 @@ pub fn train_multi_mlp(
 
     let embed_dim = category_embeddings
         .iter()
-        .flat_map(|(_, e)| e.first())
-        .next()
-        .map(|e| e.len())
-        .unwrap_or(384);
+        .find_map(|(_, e)| e.first())
+        .map_or(384, Vec::len);
 
     let feature_dim = embed_dim + num_classes * 3 + CHAR_NGRAM_DIM;
     let config = MultiCatMlpConfig::new(feature_dim, num_classes);
@@ -886,10 +882,8 @@ pub fn train_multi_models_at_startup(
         // Compute input dimension and config.
         let embed_dim = cat_embeddings
             .iter()
-            .flat_map(|(_, e)| e.first())
-            .next()
-            .map(|e| e.len())
-            .unwrap_or(384);
+            .find_map(|(_, e)| e.first())
+            .map_or(384, Vec::len);
         let num_classes = category_names.len();
         let feature_dim = embed_dim + num_classes * 3 + CHAR_NGRAM_DIM;
         let config = MultiCatMlpConfig::new(feature_dim, num_classes);

--- a/src/model.rs
+++ b/src/model.rs
@@ -23,7 +23,8 @@ pub enum ModelChoice {
 }
 
 impl ModelChoice {
-    pub fn as_str(&self) -> &'static str {
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
         match self {
             Self::AllMiniLML6V2 => "all-MiniLM-L6-v2",
             Self::AllMiniLML6V2Q => "all-MiniLM-L6-v2-Q",
@@ -40,18 +41,24 @@ impl ModelChoice {
         }
     }
 
-    pub fn dimensions(&self) -> usize {
+    #[must_use]
+    pub const fn dimensions(self) -> usize {
         match self {
-            Self::AllMiniLML6V2 | Self::AllMiniLML6V2Q => 384,
-            Self::BGESmallENV15 | Self::BGESmallENV15Q => 384,
-            Self::BGELargeENV15 | Self::BGELargeENV15Q => 1024,
+            Self::AllMiniLML6V2
+            | Self::AllMiniLML6V2Q
+            | Self::BGESmallENV15
+            | Self::BGESmallENV15Q
+            | Self::SnowflakeArcticEmbedS
+            | Self::SnowflakeArcticEmbedSQ => 384,
             Self::NomicEmbedTextV15 | Self::NomicEmbedTextV15Q => 768,
-            Self::GTELargeENV15 | Self::GTELargeENV15Q => 1024,
-            Self::SnowflakeArcticEmbedS | Self::SnowflakeArcticEmbedSQ => 384,
+            Self::BGELargeENV15
+            | Self::BGELargeENV15Q
+            | Self::GTELargeENV15
+            | Self::GTELargeENV15Q => 1024,
         }
     }
 
-    fn to_fastembed(self) -> EmbeddingModel {
+    const fn to_fastembed(self) -> EmbeddingModel {
         match self {
             Self::AllMiniLML6V2 => EmbeddingModel::AllMiniLML6V2,
             Self::AllMiniLML6V2Q => EmbeddingModel::AllMiniLML6V2Q,
@@ -68,7 +75,8 @@ impl ModelChoice {
         }
     }
 
-    pub fn all() -> &'static [ModelChoice] {
+    #[must_use]
+    pub const fn all() -> &'static [Self] {
         &[
             Self::AllMiniLML6V2,
             Self::AllMiniLML6V2Q,
@@ -105,7 +113,7 @@ impl std::str::FromStr for ModelChoice {
             "snowflake-arctic-embed-s-Q" => Ok(Self::SnowflakeArcticEmbedSQ),
             _ => anyhow::bail!(
                 "unknown model: {s}. Available: {}",
-                ModelChoice::all()
+                Self::all()
                     .iter()
                     .map(|m| m.as_str())
                     .collect::<Vec<_>>()
@@ -121,7 +129,7 @@ impl std::fmt::Display for ModelChoice {
     }
 }
 
-/// Wrapper around fastembed's TextEmbedding with cosine similarity.
+/// Wrapper around fastembed's `TextEmbedding` with cosine similarity.
 pub struct EmbeddingEngine {
     inner: TextEmbedding,
     model: ModelChoice,
@@ -139,11 +147,13 @@ impl EmbeddingEngine {
         Ok(Self { inner, model })
     }
 
-    pub fn model(&self) -> ModelChoice {
+    #[must_use]
+    pub const fn model(&self) -> ModelChoice {
         self.model
     }
 
-    pub fn dimensions(&self) -> usize {
+    #[must_use]
+    pub const fn dimensions(&self) -> usize {
         self.model.dimensions()
     }
 

--- a/src/reference_set.rs
+++ b/src/reference_set.rs
@@ -140,7 +140,7 @@ pub fn load_reference_set(
                 let pos = c.groups.iter().find(|g| g.name == "positive");
                 let neg = c.groups.iter().find(|g| g.name == "negative");
                 if let Some(pos) = pos {
-                    let negative_phrases = phrases.negative.clone().unwrap_or_default();
+                    let negative_phrases = phrases.negative.unwrap_or_default();
                     ReferenceSetKind::Binary(BinaryEmbeddings {
                         positive: pos.embeddings.clone(),
                         positive_phrases: pos.phrases.clone(),


### PR DESCRIPTION
## Summary
- Enable clippy `pedantic`, `nursery`, and `cargo` lint groups
- Fix all resulting warnings across the codebase (13 files)

## Test plan
- [ ] CI passes (clippy, build, tests)
